### PR TITLE
Make enarx.dev primary domain

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,2 +1,1 @@
-enarx.io
 enarx.dev


### PR DESCRIPTION
Github pages only accepts one apex domain per site, this will switch it to enarx.dev.

This PR is in **preparation** of the move from enarx.io to enarx.dev, it **shouldn't be merged immediately**.