### PR TITLE
Added PR templates

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,28 @@
+<!--- Provide a general summary of your changes in the Title above -->
+
+## Description
+<!--- Describe your changes in detail -->
+
+## Motivation and Context
+<!--- Why is this change required? What problem does it solve? -->
+<!--- If it fixes an open issue, please link to the issue here. -->
+
+## How Has This Been Tested?
+<!--- Please describe in detail how you tested your changes. -->
+<!--- Include details of your testing environment, the tests you ran to -->
+<!--- see how your change affects other areas of the code, etc. -->
+
+## Screenshots (if appropriate):
+
+## Types of Changes
+<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
+- [ ] Bug fix (non-breaking change that fixes an issue)
+- [ ] New feature (non-breaking change that adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+
+## Checklist:
+<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
+<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
+- [ ] My code follows the code style of this project.
+- [ ] My change requires a change to the documentation.
+- [ ] I have updated the documentation accordingly.

--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template_1.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template_1.md
@@ -1,0 +1,28 @@
+<!--- Provide a general summary of your changes in the Title above -->
+
+## Description
+<!--- Describe your changes in detail -->
+
+## Motivation and Context
+<!--- Why is this change required? What problem does it solve? -->
+<!--- If it fixes an open issue, please link to the issue here. -->
+
+## How Has This Been Tested?
+<!--- Please describe in detail how you tested your changes. -->
+<!--- Include details of your testing environment, the tests you ran to -->
+<!--- see how your change affects other areas of the code, etc. -->
+
+## Screenshots (if appropriate):
+
+## Types of Changes
+<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
+- [ ] Bug fix (non-breaking change that fixes an issue)
+- [ ] New feature (non-breaking change that adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+
+## Checklist:
+<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
+<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
+- [ ] My code follows the code style of this project.
+- [ ] My change requires a change to the documentation.
+- [ ] I have updated the documentation accordingly.

--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template_2.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template_2.md
@@ -1,0 +1,25 @@
+Replace any "X" below with information about your pull request.
+
+## Pull request details
+
+Provide details about your pull request and what it adds, fixes, or changes.
+
+- X
+
+## Breaking changes
+
+Describe what features are broken by this pull request and why, if any.
+
+- X
+
+## Issues fixed
+
+Enter the issue numbers resolved by this pull request below, if any.
+
+1.  X
+
+## Other relevant information
+
+Provide any other important details below.
+
+- 

--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template_3.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template_3.md
@@ -1,0 +1,18 @@
+# Description
+
+# Closes issue(s)
+
+# How to test / repro
+
+# Screenshots
+
+# Changes include
+- [ ] Bugfix (non-breaking change that solves an issue)
+- [ ] New feature (non-breaking change that adds functionality)
+- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
+
+# Checklist
+- [ ] I have tested this code
+- [ ] I have updated the Readme
+
+# Other comments

--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template_4.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template_4.md
@@ -1,0 +1,19 @@
+<!--- Provide a general summary of your changes in the Title above -->
+
+## Description
+<!--- Describe your changes in detail -->
+
+## Context
+<!--- Why is this change required? What problem does it solve? -->
+<!--- If it fixes an open issue, please link to the issue here. -->
+
+
+## Screenshots (if appropriate):
+<!--- Please add the images if necessary displaying proper execution. -->
+
+## Checklist:
+<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
+<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
+- [ ] The Code has proper linting and is standardized.
+- [ ] The changes may require additions to the documentation.
+- [ ] The changes have been added to the documentation accordingly.

--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template_5.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template_5.md
@@ -1,0 +1,16 @@
+## Bug PR Template
+
+### Title
+([Ticket#](fix): )
+
+### Summary
+(Summarize the bug encountered concisely)
+
+### Steps to reproduce
+(How one can reproduce the issue)
+
+### Relevant logs and/or screenshots
+(Paste any relevant logs - please use code blocks to format console output, logs, and code as it's very hard to read otherwise.)
+
+### Fixes
+(If you can, link to the line of code that might be responsible for the problem)


### PR DESCRIPTION
Added a few PR templates. And closes issue 39 from enarx/enarx
<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
