### PR TITLE
Fix menu - resources vs upcoming

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -101,7 +101,7 @@ const config = {
                 to: '/resources',                
               },
               {
-                label: 'Blog (Enarx)',
+                label: 'Blog',
                 to: '/resources/tags/enarxs-blog',                
               },
               {
@@ -148,15 +148,15 @@ const config = {
                 href: 'https://twitter.com/enarxproject',
               },
               {
-                label: 'Events',
+                label: 'Upcoming Events',
                 to: '/events',
               },
               {
-                label: 'Webinars',
+                label: 'Upcoming Webinars',
                 to: '/webinars',
               },
               {
-                label: 'Meetings',
+                label: 'Upcoming Meetings',
                 href: '/meetings',
               },
             ],
@@ -213,7 +213,7 @@ const config = {
                 to: '/resources',                
               },
               {
-                label: 'Blog (Enarx)',
+                label: 'Blog',
                 to: '/resources/tags/enarxs-blog',                
               },
               {
@@ -258,15 +258,15 @@ const config = {
                 href: 'https://twitter.com/enarxproject',
               },
               {
-                label: 'Events',
+                label: 'Upcoming Events',
                 to: '/events',
               },
               {
-                label: 'Webinars',
+                label: 'Upcoming Webinars',
                 to: '/webinars',
               },
               {
-                label: 'Meetings',
+                label: 'Upcoming Meetings',
                 href: '/meetings',
               },
             ],


### PR DESCRIPTION
Add **upcoming** events, webinars, and meetings to differentiate from past events under resources.

Signed-off-by: Nick Vidal <nick@profian.com>