### PR TITLE
Organize WebAssembly Guide sidebar

### DIFF
--- a/docs/WebAssembly/Introduction.md
+++ b/docs/WebAssembly/Introduction.md
@@ -1,7 +1,7 @@
 # Introduction
 
-WebAssembly also known as WASM (Web Assembly State Machine) is not just a programming language or instruction set, it is also a compilation target for other languages to compile to, as well as a language in itself.
+WebAssembly (abbreviated Wasm) is a binary instruction format for a stack-based virtual machine. Wasm is designed as a portable target for compilation of high-level languages.
 
-Enarx provides a WebAssembly runtime, based on wasmtime, offering developers a wide range of language choices for implementation, including Rust, C, C++, C#, Go, Java, Python and Haskell.
+Enarx provides a WebAssembly runtime, based on wasmtime, offering developers a wide range of language choices for implementation, including Rust, C, C++, and Go.
 
 This guide will show how to implement a Fibonacci example in various languages and run it on Enarx.

--- a/sidebars.js
+++ b/sidebars.js
@@ -31,7 +31,7 @@ const sidebars = {
     {
       type: 'category',
       label: 'WebAssembly Guide',
-      items: ['WebAssembly/Introduction', 'WebAssembly/Rust', 'WebAssembly/Golang', 'WebAssembly/C++', 'WebAssembly/C'],
+      items: ['WebAssembly/Introduction', 'WebAssembly/Rust', 'WebAssembly/C++', 'WebAssembly/C', 'WebAssembly/Golang', 'WebAssembly/Grain'],
     },  
     {
       type: 'category',


### PR DESCRIPTION
Add Grain language to sidebar, re-organize order of languages presented, and edit introduction. 

Signed-off-by: Nick Vidal <nick@profian.com>