### PR TITLE
Grain demo typo fix

### DIFF
--- a/docs/WebAssembly/AssemblyScript.md
+++ b/docs/WebAssembly/AssemblyScript.md
@@ -1,0 +1,61 @@
+Before we begin, it’s necessary that you have `npm` in your system.
+
+1. Setting up the environment
+    
+    To install AssemblyScript on your local system, run the command given below, and to install Wasmtime to run our .wasm file, you can take a look at their [website](https://wasmtime.dev/).
+    
+    ```
+    npm install -g assemblyscript
+    ```
+    
+    We also need to install `as-wasi`. It is an easy to use API for the AssemblyScript WASI bindings. By bindings, we mean the declared functions that would map to the `WASI` host functions. The command to do the same is :
+    
+    ```
+    npm install --save as-wasi
+    ```
+    
+2. Code
+    
+    Open your preferred text editor and make a file with .ts extension. 
+    
+    The fibonacci code in AssemblyScript is as follows :
+    
+     
+    
+    ```
+    import "wasi";
+    import { Console } from "as-wasi";
+    
+    export function fibo (n: i32): i32 {
+        if(n==1 || n==0){
+          return n;
+        }
+        else{
+          return fibo(n-1) + fibo(n-2);
+        }
+    }
+    
+    let a: i32 = fibo(7);
+    Console.log(a.toString());
+    ```
+    
+    We need to import `wasi` to add some nice defaults for compiling to `WASI` and we need to import `Console` to write to `stdout`.
+    
+3. Compiling the code
+    
+    To compile your AssemblyScript code, simply run :
+    
+    ```
+    asc fibo.ts -o fibo.wasm
+    ```
+    
+    This would generate a `fibo.wasm` file in your working directory.
+    
+
+4. Running .wasm file in Wasmtime
+    
+    To run our .wasm file in wasmtime, run the following command
+    
+    ```
+    wasmtime fibo.wasm
+    ```

--- a/docs/WebAssembly/Grain.md
+++ b/docs/WebAssembly/Grain.md
@@ -33,7 +33,7 @@
     grain fibonacci.gr
     ```
     
-    This would print `21` on your terminal and generate a `fibonacci.gr.wasm` file.
+    This would print `13` on your terminal and generate a `fibonacci.gr.wasm` file.
     
 
 4. Running .wasm file in Wasmtime


### PR DESCRIPTION
## 🛠️ Fixes Issue
Fixes a typo in the Grain demo in WebAssembly guide.

## 👨‍💻 Changes proposed
Changed the number 21 to 13.

## ✔️ Check List (Check all the applicable boxes) <!-- Follow the below conventions to check the box -->
- [ ] My code follows the code style of this project.
- [ ] This PR does not contain plagiarized content.
- [ ] The title of my pull request is a short description of the requested changes.

## 📄 Note to reviewers
No changes to the code, fixed a typo in the documentation.
